### PR TITLE
Useless cat award

### DIFF
--- a/bastet
+++ b/bastet
@@ -11,8 +11,8 @@ arg7="search"
 
 ### Checking if the config file exists and using it when available
 if test -f /etc/bastet/config; then
-    zugaina="$(cat /etc/bastet/config | grep zugaina | cut -c 11-)"
-    eixcheck="$(cat /etc/bastet/config | grep eix | cut -c 7-)"
+    zugaina="$(grep zugaina /etc/bastet/config | cut -c 11-)"
+    eixcheck="$(grep eix /etc/bastet/config | cut -c 7-)"
 else
     zugaina=true
     eixcheck=true


### PR DESCRIPTION
Referencing http://porkmail.org/era/unix/award.html

![image](https://user-images.githubusercontent.com/11302521/65634678-0d93c580-dfdf-11e9-9756-e4d7a0f22b7d.png)

```bash
zugaina="$(cat /etc/bastet/config | grep zugaina | cut -c 11-)"
eixcheck="$(cat /etc/bastet/config | grep eix | cut -c 7-)"
```
And of course, if you've been following along for a week or two, you know
that this (BING!) is a Useless Use of Cat!

Rememeber, nearly all cases where you have:

        `cat file | some_command and its args ...`

you can rewrite it as:

        `<file some_command and its args ...`

and in some cases, such as this one, you can move the filename
to the arglist as in:

        `some_command and its args ... file`

Just another Useless Use of Usenet,
Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>

---

Welcome to github 